### PR TITLE
Fix 1.21.8 pack.mcmeta

### DIFF
--- a/pack.mcmeta
+++ b/pack.mcmeta
@@ -1,9 +1,10 @@
 {
   "pack": {
-    "pack_format": 63,
     "description": "The go-to 32x resource pack.\n§8December 2025 Release",
+    "pack_format": 63,
     "supported_formats": {
       "min_inclusive": 63,
       "max_inclusive": 64
     }
   }
+}

--- a/pack.mcmeta
+++ b/pack.mcmeta
@@ -1,7 +1,6 @@
 {
   "pack": {
     "description": "The go-to 32x resource pack.\n§8December 2025 Release",
-    "min_format": 56,
-    "max_format": 64
+    "pack_format": 64
   }
 }

--- a/pack.mcmeta
+++ b/pack.mcmeta
@@ -1,6 +1,9 @@
 {
   "pack": {
+    "pack_format": 63,
     "description": "The go-to 32x resource pack.\n§8December 2025 Release",
-    "pack_format": 64
+    "supported_formats": {
+      "min_inclusive": 63,
+      "max_inclusive": 64
+    }
   }
-}


### PR DESCRIPTION
1.21.8 still uses the older "supported_formats" system (also how do i disable copilot autocomplete mhhh)